### PR TITLE
change Uri.fromString(uristring) to Uri.parse(uriString). 

### DIFF
--- a/lib/src/browser/proxy_callback.dart
+++ b/lib/src/browser/proxy_callback.dart
@@ -50,7 +50,7 @@ class _ProxyChannel {
 
   /// Computes the javascript origin of an absolute URI.
   String _origin(String uriString) {
-    final uri = new Uri.fromString(uriString);
+    final uri = Uri.parse(uriString);
     final portPart = (uri.port != 0) ? ":${uri.port}" : "";
     return "${uri.scheme}://${uri.domain}$portPart";
   }
@@ -59,7 +59,7 @@ class _ProxyChannel {
     Map<String, String> proxyParams = {"parent": window.location.origin};
     String proxyUrl = new UrlPattern("${_provider}postmessageRelay")
         .generate({}, proxyParams);
-    return new Uri.fromString(proxyUrl)
+    return Uri.parse(proxyUrl)
         .resolve("#rpctoken=$_nonce&forcesecure=1").toString();
   }
 }

--- a/lib/src/browser/token.dart
+++ b/lib/src/browser/token.dart
@@ -104,7 +104,7 @@ class Token {
 
   /// Extracts &-separated tokens from the path, query, and fragment of [uri].
   static List<String> _tokenizeRelativeUrl(String uri) {
-    final u = new Uri.fromString(uri);
+    final u = Uri.parse(uri);
     final result = [];
     [u.path, u.query, u.fragment].forEach((x) {
       if (x != null) result.addAll(_tokenize(x));


### PR DESCRIPTION
Uri.fromString() constructor has been removed in Dart Editor build 22416.
I Tried to fix it.Please check my pull request.
Thanks.
