### PR TITLE
fix return type of SafeHttpServer.close

### DIFF
--- a/lib/src/console/oauth2_console_client/safe_http_server.dart
+++ b/lib/src/console/oauth2_console_client/safe_http_server.dart
@@ -30,7 +30,7 @@ class SafeHttpServer extends StreamView<HttpRequest> implements HttpServer {
       : super(server),
         _inner = server;
 
-  void close() => _inner.close();
+  Future close() => _inner.close();
 
   int get port => _inner.port;
 


### PR DESCRIPTION
changed it from void to Future to avoid crashes
