### PR TITLE
Auto load stored token

### DIFF
--- a/lib/src/browser/google_oauth2.dart
+++ b/lib/src/browser/google_oauth2.dart
@@ -156,7 +156,7 @@ class GoogleOAuth2 extends OAuth2<Token> {
         _tokenCompleter = _wrapValidation(tokenCompleter);
         if (onlyLoadToken){
           //Remove current login attempt because prompting user is disabled by onlyLoadToken
-          _tokenCompleter.completeError("Could not load token from Local Storage");
+          _tokenCompleter.completeError("Google OAuth2 token not saved in Local Storage");
         } else {
           // Synchronous if the channel is already open -> avoids popup blocker
 


### PR DESCRIPTION
Added `autoLoadStoredToken` option that automatically logs in but only if a previously stored token is present in Local Storage. Logging out removes this stored token. Addresses issue #51 where when using `autoLogin` would automatically login even after the user has clicked logout.
