### PR TITLE
Fix documentation comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Initialize the library with your parameters
 
 ```
 final auth = new GoogleOAuth2(
-  "YOUR CLIENT ID HERE",
-  ["scope1", "scope2", ...],
-  tokenLoaded:oauthReady,
-  autoLogin: <true/false>);
+    "YOUR CLIENT ID HERE",
+    ["scope1", "scope2", ...],
+    tokenLoaded: oauthReady,
+    autoLogin: <true/false>);
 ```
 
-The `oauthReady` function will be called once your app has a valid OAuth token to call the APIs.
+The `oauthReady` function (a function you must define) will be called once your app has a valid OAuth token to call the APIs.
 If you set `autoLogin` to `true` and the user has authorized the app in the past, this will happen automatically.
 Otherwise, you need to call `auth.login()` to trigger a confirmation dialog.
 

--- a/lib/src/browser/google_oauth2.dart
+++ b/lib/src/browser/google_oauth2.dart
@@ -21,19 +21,24 @@ class GoogleOAuth2 extends OAuth2<Token> {
   /// The last fetched token.
   Token __token; // Double-underscore because it has a private setter _token.
 
-  /// Constructor.
-  ///
-  /// @param provider the URI to provide Google OAuth2 authentication.
-  /// @param tokenValidationUri the URI to validate OAuth2 tokens against.
-  /// @param clientId Client id for the Google API app. Eg, for Google Books, use
-  ///        "796343192238.apps.googleusercontent.com",
-  /// @param scopes list of scopes (kinds of information) you are planning to use. For example, to
-  ///        get data related to Google Books and user info, use
-  ///        `["https://www.googleapis.com/auth/books", "https://www.googleapis.com/auth/userinfo.email"]`
-  /// @param tokenLoaded a callback to use when a non-null login token is ready
-  /// @param approval_prompt can be null or 'force' to force user approval or 'auto' (default)
-  /// @param autoLogin if true, try to login with "immediate" param (no popup will be shown)
-  /// @param onlyLoadToken instead of showing user prompt, use stored token (if available)
+  /**
+   * Constructor.
+   *
+   * The following parameters are accepted:
+   *
+   * * [provider] the URI to provide Google OAuth2 authentication.
+   * * [tokenValidationUri] the URI to validate OAuth2 tokens against.
+   * * [clientId] Client id for the Google API app. For example, for Google
+   *   Books, use "796343192238.apps.googleusercontent.com".
+   * * [scopes] list of scopes (kinds of information) you are planning to use.
+   *   For example, to get data related to Google Books and user info, use
+   *   `["https://www.googleapis.com/auth/books", "https://www.googleapis.com/auth/userinfo.email"]`
+   * * [tokenLoaded] a callback to use when a non-null login token is ready.
+   *   The callback should accept one [Token] parameter.
+   * * [approval_prompt] can be null or 'force' to force user approval or 'auto' (default)
+   * * [autoLogin] if true, try to login with "immediate" param (no popup will be shown)
+   * * [onlyLoadToken] instead of showing user prompt, use stored token (if available)
+   */
   GoogleOAuth2(
       String this._clientId,
       List<String> this._scopes,
@@ -124,19 +129,22 @@ class GoogleOAuth2 extends OAuth2<Token> {
     _token = null;
   }
 
-  /// Attempts to authenticate.
-  ///
-  /// Scenarios:
-  ///
-  /// * If you have an existing valid token, it will be immediately returned.
-  /// * If you have an expired token, it will be silently renewed (override
-  ///   with immediate:true)
-  /// * If you have no token, a popup prompt will be displayed.
-  /// * If the user declines, closes the popup, or the service returns a token
-  ///   that cannot be validated, an exception will be delivered.
-  ///   
-  /// @param immediate authenticate user with the "immediate" parameter. No popup will be shown.
-  /// @param onlyLoadToken instead of showing user prompt, use stored token (if available)
+  /**
+   * Attempts to authenticate.
+   *
+   * Scenarios:
+   *
+   * * If you have an existing valid token, it will be immediately returned.
+   * * If you have an expired token, it will be silently renewed (override with
+   *   `immediate: true`)
+   * * If you have no token, a popup prompt will be displayed.
+   * * If the user declines, closes the popup, or the service returns a token
+   *   that cannot be validated, an exception will be delivered.
+   *
+   * If [immediate] is true, authenticates user with the "immediate" parameter.
+   * No popup will be shown. If [onlyLoadToken] is true, then use stored token
+   * (if available) instead of showing user prompt.
+   */
   Future<Token> login({bool immediate: false, bool onlyLoadToken: false}) {
     if ((_approval_prompt == "force") && immediate) {
       return new Future<Token>.error("Can't force approval prompt with immediate login");

--- a/lib/src/browser/oauth2.dart
+++ b/lib/src/browser/oauth2.dart
@@ -8,7 +8,8 @@ abstract class OAuth2<T> {
   OAuth2();
 
   /**
-   * Take a [request] and return the request with the authorization headers set correctly
+   * Takes a [request] and returns the request with the authorization headers
+   * set correctly.
    */
   Future<HttpRequest> authenticate(HttpRequest request) {
     return ensureAuthenticated()

--- a/lib/src/browser/simple_oauth2.dart
+++ b/lib/src/browser/simple_oauth2.dart
@@ -2,7 +2,7 @@ part of google_oauth2_browser;
 
 /**
  *  A simple OAuth2 authentication context which can use if you already have a [token]
- *  via another mechanism, like f.e. the Chrome Extension Identity API
+ *  via another mechanism, for example the Chrome Extension Identity API.
  */
 class SimpleOAuth2 extends OAuth2<String> {
   final String token;

--- a/lib/src/browser/token.dart
+++ b/lib/src/browser/token.dart
@@ -33,7 +33,9 @@ class Token {
   String toString() => "[Token type=$type, data=$data, expired=$expired, "
       "expiry=$expiry, email=$email, userId=$userId]";
 
-  /// Query whether this token is still valid.
+  /**
+   * Queries whether this token is still valid.
+   */
   Future<bool> validate(String clientId,
       {String service: "https://www.googleapis.com/oauth2/v1/tokeninfo"}) {
     String url = UrlPattern.generatePattern(service, {}, {"access_token": data});

--- a/lib/src/common/url_pattern.dart
+++ b/lib/src/common/url_pattern.dart
@@ -8,8 +8,8 @@ class UrlPattern {
   final List<_UrlPatternToken> _tokens;
 
   /**
-   * Creates a UrlPattern from the specification [:pattern:].
-   * See http://tools.ietf.org/html/draft-gregorio-uritemplate-07
+   * Creates a UrlPattern from the specification [pattern].
+   * See <http://tools.ietf.org/html/draft-gregorio-uritemplate-07>.
    * We only implement a very simple subset for now.
    */
   UrlPattern(String pattern) : _tokens = [] {
@@ -36,7 +36,7 @@ class UrlPattern {
     }
   }
 
-  /** Generate a URL with the specified list of URL and query parameters. */
+  /** Generates a URL with the specified list of URL and query parameters. */
   String generate(Map<String, Object> urlParams, Map<String, Object> queryParams) {
     final buffer = new StringBuffer();
     _tokens.forEach((token) => buffer.write(token(urlParams)));


### PR DESCRIPTION
The documentation (mostly for constructors) is broken at [dartdocs](http://www.dartdocs.org/documentation/google_oauth2_client/0.4.0/index.html#google_oauth2_client/google_oauth2_browser.GoogleOAuth2)

This PR converts some of the comments to Markdown, so that they appear ok. I added a few periods, changed a few one-liners to the third-person present tense ("take a request" --> "takes a request") and not much else.

I also added a bit to the README, where I got confused, not understanding that I needed to provide my own `oauthReady` :tongue: . Let me know if anything is not to your liking.
